### PR TITLE
Stabilize CIPP processor batch ordering

### DIFF
--- a/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-OrchestratorBatchItems.ps1
+++ b/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/Push-OrchestratorBatchItems.ps1
@@ -8,7 +8,14 @@ function Push-OrchestratorBatchItems {
 
     if ($Item.Parameters.BatchId) {
         $Table = Get-CippTable -TableName 'CippOrchestratorBatch'
-        $Entities = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq '$($Item.Parameters.BatchId)'"
+        $Entities = Get-CIPPAzDataTableEntity @Table -Filter "PartitionKey eq '$($Item.Parameters.BatchId)'" | Sort-Object @{ Expression = {
+                if ($null -ne $_.BatchIndex) {
+                    [int]$_.BatchIndex
+                } else {
+                    [int]::MaxValue
+                }
+            }
+        }, RowKey
         $BatchItems = [system.Collections.Generic.List[object]]::new()
         $Entities | ForEach-Object {
             $Item = $_.BatchItem | ConvertFrom-Json

--- a/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-CIPPOrchestrator.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-CIPPOrchestrator.ps1
@@ -98,13 +98,16 @@ function Start-CIPPOrchestrator {
         if ($InputObject.Batch) {
             # Store batch items separately to enable querying and tracking
             $BatchGuid = (New-Guid).Guid.ToString()
+            $BatchIndex = 0
             foreach ($BatchItem in $InputObject.Batch) {
                 $BatchEntity = @{
                     PartitionKey = $BatchGuid
-                    RowKey       = (New-Guid).Guid.ToString()
+                    RowKey       = '{0:D8}-{1}' -f $BatchIndex, (New-Guid).Guid.ToString()
+                    BatchIndex   = $BatchIndex
                     BatchItem    = [string]($BatchItem | ConvertTo-Json -Depth 10 -Compress)
                 }
                 Add-CIPPAzDataTableEntity @BatchTable -Entity $BatchEntity -Force
+                $BatchIndex++
             }
 
             # Remove batch from main input object to reduce size
@@ -166,13 +169,16 @@ function Start-CIPPOrchestrator {
 
             if ($InputObject.Batch) {
                 # Store batch items separately to enable querying and tracking
+                $BatchIndex = 0
                 foreach ($BatchItem in $InputObject.Batch) {
                     $BatchEntity = @{
                         PartitionKey = $Guid
-                        RowKey       = (New-Guid).Guid.ToString()
+                        RowKey       = '{0:D8}-{1}' -f $BatchIndex, (New-Guid).Guid.ToString()
+                        BatchIndex   = $BatchIndex
                         BatchItem    = [string]($BatchItem | ConvertTo-Json -Depth 10 -Compress)
                     }
                     Add-CIPPAzDataTableEntity @BatchTable -Entity $BatchEntity -Force
+                    $BatchIndex++
                 }
 
                 # Remove batch from main input object to reduce size

--- a/Modules/CIPPCore/Public/GraphHelper/Write-LogMessage.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/Write-LogMessage.ps1
@@ -13,14 +13,31 @@ function Write-LogMessage {
         $sev,
         $LogData = ''
     )
-    if ($Headers.'x-ms-client-principal-idp' -eq 'azureStaticWebApps' -or !$Headers.'x-ms-client-principal-idp') {
-        $user = $headers.'x-ms-client-principal'
-        $username = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($user)) | ConvertFrom-Json).userDetails
+    if (!$Headers -and $script:CippRequestHeadersStorage -and $script:CippRequestHeadersStorage.Value) {
+        $Headers = $script:CippRequestHeadersStorage.Value
+    }
+
+    $ClientPrincipal = $null
+    if ($Headers.'x-ms-client-principal') {
+        try {
+            $user = $headers.'x-ms-client-principal'
+            $ClientPrincipal = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($user)) | ConvertFrom-Json
+            $username = $ClientPrincipal.userDetails
+            $UserId = $ClientPrincipal.userId
+            $UserIdp = $Headers.'x-ms-client-principal-idp'
+        } catch {
+            $username = $user
+        }
     } elseif ($Headers.'x-ms-client-principal-idp' -eq 'aad') {
         $Table = Get-CIPPTable -TableName 'ApiClients'
         $Client = Get-CIPPAzDataTableEntity @Table -Filter "RowKey eq '$($headers.'x-ms-client-principal-name')'"
         $username = $Client.AppName ?? 'CIPP-API'
         $AppId = $headers.'x-ms-client-principal-name'
+        $UserIdp = $Headers.'x-ms-client-principal-idp'
+    } elseif ($Headers.'x-ms-client-principal-name') {
+        $username = $Headers.'x-ms-client-principal-name'
+        $UserId = $Headers.'x-ms-client-principal-id'
+        $UserIdp = $Headers.'x-ms-client-principal-idp'
     } else {
         try {
             $username = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($user)) | ConvertFrom-Json).userDetails
@@ -64,6 +81,12 @@ function Write-LogMessage {
     }
     if ($AppId) {
         $TableRow.AppId = [string]$AppId
+    }
+    if ($UserId) {
+        $TableRow.ActorId = [string]$UserId
+    }
+    if ($UserIdp) {
+        $TableRow.ActorIdentityProvider = [string]$UserIdp
     }
     if ($tenantId) {
         $TableRow.Add('TenantID', [string]$tenantId)

--- a/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPGraphWebhookRenewal.ps1
+++ b/Modules/CIPPCore/Public/Webhooks/Invoke-CIPPGraphWebhookRenewal.ps1
@@ -15,6 +15,23 @@ function Invoke-CippGraphWebhookRenewal {
 
     if (($WebhookData | Measure-Object).Count -gt 0) {
         Write-LogMessage -API 'Scheduler_RenewGraphSubscriptions' -tenant 'none' -message 'Starting Graph Subscription Renewal' -sev Info
+        $WebhookData = $WebhookData | Group-Object -Property PartitionKey, Resource, EventType, TypeofSubscription | ForEach-Object {
+            $GroupedSubscriptions = @($_.Group | Sort-Object -Property @{ Expression = { Get-Date($_.Expiration) }; Descending = $true })
+            $SubscriptionToRenew = $GroupedSubscriptions | Select-Object -First 1
+            $DuplicateSubscriptions = $GroupedSubscriptions | Select-Object -Skip 1
+
+            foreach ($DuplicateSub in $DuplicateSubscriptions) {
+                try {
+                    Write-LogMessage -API 'Renew_Graph_Subscriptions' -message "Removing duplicate renewal row for $($DuplicateSub.SubscriptionID) as $($SubscriptionToRenew.SubscriptionID) is the newest $($DuplicateSub.EventType) subscription for $($DuplicateSub.Resource)." -sev 'Warning' -tenant $DuplicateSub.PartitionKey
+                    Remove-AzDataTableEntity -Force @WebhookTable -Entity $DuplicateSub
+                } catch {
+                    Write-LogMessage -API 'Renew_Graph_Subscriptions' -message "Failed to remove duplicate renewal row for $($DuplicateSub.SubscriptionID). Error: $($_.Exception.message)" -Sev 'Warning' -tenant $DuplicateSub.PartitionKey
+                }
+            }
+
+            $SubscriptionToRenew
+        }
+
         foreach ($UpdateSub in $WebhookData) {
             try {
                 $TenantFilter = $UpdateSub.PartitionKey

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/New-CippCoreRequest.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/New-CippCoreRequest.ps1
@@ -29,6 +29,10 @@ function New-CippCoreRequest {
     if (-not $script:CippUserRolesStorage) {
         $script:CippUserRolesStorage = [System.Threading.AsyncLocal[hashtable]]::new()
     }
+    if (-not $script:CippRequestHeadersStorage) {
+        $script:CippRequestHeadersStorage = [System.Threading.AsyncLocal[object]]::new()
+    }
+    $script:CippRequestHeadersStorage.Value = $Request.Headers
 
     # Initialize user roles cache for this request
     if (-not $script:CippUserRolesStorage.Value) {
@@ -129,7 +133,7 @@ function New-CippCoreRequest {
 
             try {
                 Write-Information "Access: $Access"
-                Write-LogMessage -headers $Headers -API $Request.Params.CIPPEndpoint -message 'Accessed this API' -Sev 'Debug'
+                Write-LogMessage -headers $Request.Headers -API $Request.Params.CIPPEndpoint -message 'Accessed this API' -Sev 'Debug'
                 if ($Access) {
                     # Prepare telemetry metadata for HTTP API call
                     $metadata = @{
@@ -149,6 +153,14 @@ function New-CippCoreRequest {
                     # Add user info if available
                     if ($Request.Headers.'x-ms-client-principal-name') {
                         $metadata['User'] = $Request.Headers.'x-ms-client-principal-name'
+                    } elseif ($Request.Headers.'x-ms-client-principal') {
+                        try {
+                            $ClientPrincipal = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Request.Headers.'x-ms-client-principal')) | ConvertFrom-Json
+                            $metadata['User'] = $ClientPrincipal.userDetails
+                            $metadata['UserId'] = $ClientPrincipal.userId
+                        } catch {
+                            $metadata['User'] = 'Unknown'
+                        }
                     }
 
                     # Wrap the API call execution with telemetry

--- a/Modules/CippEntrypoints/CippEntrypoints.psm1
+++ b/Modules/CippEntrypoints/CippEntrypoints.psm1
@@ -258,9 +258,11 @@ function Receive-CippOrchestrationTrigger {
         Write-Information "Durable Mode: $DurableMode"
 
         $RetryOptions = New-DurableRetryOptions @DurableRetryOptions
-        if (!$OrchestratorInput.Batch -or ($OrchestratorInput.Batch | Measure-Object).Count -eq 0 -and $OrchestratorInput.QueueFunction) {
+        $HasBatch = $OrchestratorInput.Batch -and (($OrchestratorInput.Batch | Measure-Object).Count -gt 0)
+        $HasQueueFunction = $null -ne $OrchestratorInput.QueueFunction
+        if (-not $HasBatch -and $HasQueueFunction) {
             $Batch = (Invoke-ActivityFunction -FunctionName 'CIPPActivityFunction' -Input $OrchestratorInput.QueueFunction -ErrorAction Stop) | Where-Object { $null -ne $_.FunctionName }
-        } elseif ($OrchestratorInput.Batch) {
+        } elseif ($HasBatch) {
             $Batch = $OrchestratorInput.Batch | Where-Object { $null -ne $_.FunctionName }
         } else {
             Write-Information 'No batch or queue function provided to orchestrator input'
@@ -576,4 +578,3 @@ function Receive-CIPPTimerTrigger {
 }
 
 Export-ModuleMember -Function @('Receive-CippHttpTrigger', 'Receive-CippQueueTrigger', 'Receive-CippOrchestrationTrigger', 'Receive-CippActivityTrigger', 'Receive-CIPPTimerTrigger')
-


### PR DESCRIPTION
## Summary
- Carries forward Kalleo-local webhook renewal dedupe and audit-attribution work from the prior local branch.
- Adds stable BatchIndex values when CIPP stores orchestrator batch items in table storage.
- Sorts retrieved orchestrator batch items by BatchIndex, with RowKey fallback for older rows.
- Makes the orchestrator batch-vs-queue-function branch explicit to avoid ambiguous PowerShell boolean precedence.

## Why
Our Azure-hosted CIPP instance has shown processor churn, recurring Durable nondeterministic workflow failures, webhook duplication symptoms, high background execution cost, and weak technician attribution in CIPP-side logs. This PR keeps the changes scoped to the Kalleo fork and avoids Azure spend increases.

## Scope
- Kalleo fork only: wjohnsonkalleo/CIPP-API
- No upstream KelvinTegelaar push
- No Azure spend increase
- No Azure resources modified by this PR
- No secrets or payload logging

## Validation
- PowerShell parser validation passed for the three newly changed processor files.
- JSON validation passed for Config/CIPPTimers.json and Config/FeatureFlags.json.
- git diff --check passed.

## Rollback
Revert this PR. Existing batch rows without BatchIndex remain supported through the RowKey fallback.