### PR TITLE
Add targeted monthly BPA scheduling

### DIFF
--- a/Config/CIPPTimers.json
+++ b/Config/CIPPTimers.json
@@ -177,9 +177,9 @@
   },
   {
     "Id": "80070b4f-95ed-4e5f-be4c-9e339306d4aa",
-    "Command": "Start-BPAOrchestrator",
-    "Description": "Orchestrator to process BPA reports",
-    "Cron": "0 0 3 * * *",
+    "Command": "Start-BPAMonthlyOrchestrator",
+    "Description": "Orchestrator to process BPA reports monthly per tenant",
+    "Cron": "0 20 3 * * *",
     "Priority": 10,
     "TZOffset": true,
     "RunOnProcessor": true

--- a/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/BPA/Push-BPACollectData.ps1
+++ b/Modules/CIPPActivityTriggers/Public/Entrypoints/Activity Triggers/BPA/Push-BPACollectData.ps1
@@ -20,7 +20,15 @@ function Push-BPACollectData {
     }
     $Table = Get-CippTable -tablename 'cachebpav2'
 
-    $Rerun = Test-CIPPRerun -Type 'BPA' -Tenant $Item.Tenant -API $Item.Template
+    $RerunParams = @{
+        Type         = 'BPA'
+        TenantFilter = $Item.Tenant
+        API          = $Item.Template
+    }
+    if ($Item.RerunIntervalSeconds -and [int64]$Item.RerunIntervalSeconds -gt 0) {
+        $RerunParams.Interval = [int64]$Item.RerunIntervalSeconds
+    }
+    $Rerun = Test-CIPPRerun @RerunParams
     if ($Rerun) {
         Write-Host 'Detected rerun for BPA. Exiting cleanly'
         return

--- a/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAMonthlyOrchestrator.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAMonthlyOrchestrator.ps1
@@ -1,0 +1,115 @@
+function Start-BPAMonthlyOrchestrator {
+    <#
+    .SYNOPSIS
+        Starts targeted monthly BPA runs without launching all tenants at once.
+    .DESCRIPTION
+        Checks which tenants are due for their monthly Best Practice Analyser run, queues
+        a limited number of tenant-specific BPA orchestrations, and records queue state.
+    .FUNCTIONALITY
+        Entrypoint
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        $TenantFilter = 'AllTenants',
+        [int]$MaxTenantsPerRun = 5,
+        [int]$RerunIntervalDays = 30
+    )
+
+    try {
+        $FeatureFlag = Get-CIPPFeatureFlag -Id 'BestPracticeAnalyser'
+        if ($FeatureFlag -and $FeatureFlag.Enabled -eq $false) {
+            Write-LogMessage -API 'BestPracticeAnalyser' -message 'Monthly BPA scheduler skipped because Best Practice Analyser is disabled via feature flag' -sev Info
+            return $false
+        }
+
+        if ($MaxTenantsPerRun -lt 1) {
+            $MaxTenantsPerRun = 1
+        }
+
+        if ($env:CIPP_BPA_MONTHLY_MAX_TENANTS -and $env:CIPP_BPA_MONTHLY_MAX_TENANTS -match '^\d+$') {
+            $MaxTenantsPerRun = [int]$env:CIPP_BPA_MONTHLY_MAX_TENANTS
+        }
+
+        if ($env:CIPP_BPA_MONTHLY_RERUN_DAYS -and $env:CIPP_BPA_MONTHLY_RERUN_DAYS -match '^\d+$') {
+            $RerunIntervalDays = [int]$env:CIPP_BPA_MONTHLY_RERUN_DAYS
+        }
+
+        $Now = (Get-Date).ToUniversalTime()
+        $CurrentMonth = $Now.ToString('yyyy-MM')
+        $RerunIntervalSeconds = [int64]$RerunIntervalDays * 86400
+
+        if ($TenantFilter -ne 'AllTenants') {
+            if ($TenantFilter -match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') {
+                $TenantList = @(Get-Tenants -TenantFilter $TenantFilter)
+            } else {
+                $TenantList = @(Get-Tenants | Where-Object { $_.defaultDomainName -eq $TenantFilter -or $_.customerId -eq $TenantFilter })
+            }
+        } else {
+            $TenantList = @(Get-Tenants)
+        }
+
+        if (($TenantList | Measure-Object).Count -eq 0) {
+            Write-Information 'Monthly BPA scheduler found no tenants to evaluate'
+            return 0
+        }
+
+        $StateTable = Get-CippTable -TableName 'BPAScheduleState'
+        $StateRows = @(Get-CIPPAzDataTableEntity @StateTable -Filter "PartitionKey eq 'MonthlyBPA'")
+
+        $DueTenants = foreach ($Tenant in $TenantList) {
+            $TenantDomain = $Tenant.defaultDomainName
+            $TenantId = $Tenant.customerId ?? $TenantDomain
+            if (!$TenantDomain -or !$TenantId) {
+                continue
+            }
+
+            $HashInput = [System.Text.Encoding]::UTF8.GetBytes([string]$TenantId)
+            $Hash = [System.Security.Cryptography.SHA256]::Create().ComputeHash($HashInput)
+            $AssignedDay = ([System.BitConverter]::ToUInt32($Hash, 0) % 28) + 1
+            $State = $StateRows | Where-Object { $_.RowKey -eq $TenantId } | Select-Object -First 1
+            $AlreadyQueuedThisMonth = $State.LastQueuedMonth -eq $CurrentMonth
+
+            # Run tenants on their assigned day, with a month-end catch-up window.
+            $DueToday = $AssignedDay -le $Now.Day -or $Now.Day -ge 28
+            if ($DueToday -and !$AlreadyQueuedThisMonth) {
+                [PSCustomObject]@{
+                    TenantDomain = $TenantDomain
+                    TenantId     = $TenantId
+                    AssignedDay  = [int]$AssignedDay
+                    LastQueued   = $State.LastQueuedUtc ?? ''
+                }
+            }
+        }
+
+        $DueTenants = @($DueTenants | Sort-Object AssignedDay, TenantDomain | Select-Object -First $MaxTenantsPerRun)
+        if (($DueTenants | Measure-Object).Count -eq 0) {
+            Write-Information 'Monthly BPA scheduler found no tenants due for BPA today'
+            return 0
+        }
+
+        if ($PSCmdlet.ShouldProcess("Monthly BPA for $($DueTenants.Count) tenant(s)", 'Queue tenant-targeted BPA orchestrations')) {
+            foreach ($Tenant in $DueTenants) {
+                Write-LogMessage -API 'BestPracticeAnalyser' -tenant $Tenant.TenantDomain -message "Queueing monthly BPA for $($Tenant.TenantDomain)" -sev Info
+                $OrchestratorId = Start-BPAOrchestrator -TenantFilter $Tenant.TenantDomain -RerunIntervalSeconds $RerunIntervalSeconds
+
+                $StateEntity = @{
+                    PartitionKey       = 'MonthlyBPA'
+                    RowKey             = [string]$Tenant.TenantId
+                    Tenant             = [string]$Tenant.TenantDomain
+                    AssignedDay        = [int]$Tenant.AssignedDay
+                    LastQueuedUtc      = [string]$Now.ToString('o')
+                    LastQueuedMonth    = [string]$CurrentMonth
+                    LastOrchestratorId = [string]$OrchestratorId
+                    Status             = 'Queued'
+                }
+                Add-CIPPAzDataTableEntity @StateTable -Entity $StateEntity -Force
+            }
+        }
+
+        return $DueTenants.Count
+    } catch {
+        $ErrorMessage = Get-CippException -Exception $_
+        Write-LogMessage -API 'BestPracticeAnalyser' -message "Could not run monthly BPA scheduler: $($ErrorMessage.NormalizedError)" -sev Error -LogData $ErrorMessage
+        return $false
+    }
+}

--- a/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAOrchestrator.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAOrchestrator.ps1
@@ -10,6 +10,7 @@ function Start-BPAOrchestrator {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         $TenantFilter = 'AllTenants',
+        [int64]$RerunIntervalSeconds = 0,
         [switch]$Force
     )
 
@@ -69,6 +70,7 @@ function Start-BPAOrchestrator {
                     FunctionName = 'BPACollectData'
                     Tenant       = $Tenant
                     Template     = $Template
+                    RerunIntervalSeconds = $RerunIntervalSeconds
                     QueueName    = '{0} - {1}' -f $Template, $Tenant
                 }
             }


### PR DESCRIPTION
## Summary
- Replaces the BPA timer command with a targeted monthly BPA scheduler instead of the old daily all-tenant BPA runner.
- Adds Start-BPAMonthlyOrchestrator to stagger tenants by deterministic assigned day of month.
- Limits queued tenants per run, default 5, with optional environment overrides.
- Passes a monthly rerun interval into BPA collection so scheduled BPA work does not re-run every 24 hours.

## Why
BPA can be useful for MSP onboarding, QBRs, and monthly client posture checks, but running it daily across every tenant creates unnecessary Graph/API, Functions, and storage workload. This keeps BPA useful while avoiding a recurring all-tenant background flood.

## Operational behavior
- Timer still runs daily as a lightweight due-date check.
- Tenants are spread across days 1-28 using a stable tenant ID hash.
- Month-end catch-up runs tenants not queued earlier in the month.
- Default cap is 5 tenants per scheduler run.
- BPA remains feature-flag controlled.

## Cost impact
Expected to reduce BPA-related Azure workload compared with the previous daily all-tenant timer. No new Azure services, plans, retention, diagnostics, or paid dependencies are introduced.

## Validation
- PowerShell parser validation passed for touched BPA files.
- Config/CIPPTimers.json JSON validation passed.
- git diff --check passed.

## Rollback
Revert this PR or change the BPA timer command back to Start-BPAOrchestrator if daily all-tenant BPA is intentionally desired.