### PR TITLE
Harden BPA routing, webhook dedupe, and audit correlation

### DIFF
--- a/Config/CIPPTimers.json
+++ b/Config/CIPPTimers.json
@@ -182,7 +182,8 @@
     "Cron": "0 20 3 * * *",
     "Priority": 10,
     "TZOffset": true,
-    "RunOnProcessor": true
+    "RunOnProcessor": true,
+    "PreferredProcessor": "proc"
   },
   {
     "Id": "54c39540-fe91-4795-8613-ac4295751a51",

--- a/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAMonthlyOrchestrator.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAMonthlyOrchestrator.ps1
@@ -16,6 +16,13 @@ function Start-BPAMonthlyOrchestrator {
     )
 
     try {
+        $CurrentFunctionApp = $env:WEBSITE_SITE_NAME
+        $IsProcessorNode = $env:CIPP_PROCESSOR -eq 'true' -or $CurrentFunctionApp -like '*-proc'
+        if (!$IsProcessorNode) {
+            Write-LogMessage -API 'BestPracticeAnalyser' -message "Monthly BPA scheduler skipped on non-processor app '$CurrentFunctionApp'" -sev Info
+            return $false
+        }
+
         $FeatureFlag = Get-CIPPFeatureFlag -Id 'BestPracticeAnalyser'
         if ($FeatureFlag -and $FeatureFlag.Enabled -eq $false) {
             Write-LogMessage -API 'BestPracticeAnalyser' -message 'Monthly BPA scheduler skipped because Best Practice Analyser is disabled via feature flag' -sev Info

--- a/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAMonthlyOrchestrator.ps1
+++ b/Modules/CIPPCore/Public/Entrypoints/Orchestrator Functions/Start-BPAMonthlyOrchestrator.ps1
@@ -17,7 +17,7 @@ function Start-BPAMonthlyOrchestrator {
 
     try {
         $CurrentFunctionApp = $env:WEBSITE_SITE_NAME
-        $IsProcessorNode = $env:CIPP_PROCESSOR -eq 'true' -or $CurrentFunctionApp -like '*-proc'
+        $IsProcessorNode = $CurrentFunctionApp -like '*-proc'
         if (!$IsProcessorNode) {
             Write-LogMessage -API 'BestPracticeAnalyser' -message "Monthly BPA scheduler skipped on non-processor app '$CurrentFunctionApp'" -sev Info
             return $false

--- a/Modules/CIPPCore/Public/GraphHelper/Write-LogMessage.ps1
+++ b/Modules/CIPPCore/Public/GraphHelper/Write-LogMessage.ps1
@@ -82,6 +82,9 @@ function Write-LogMessage {
     if ($AppId) {
         $TableRow.AppId = [string]$AppId
     }
+    if ($script:CippInvocationIdStorage -and $script:CippInvocationIdStorage.Value) {
+        $TableRow.InvocationId = [string]$script:CippInvocationIdStorage.Value
+    }
     if ($UserId) {
         $TableRow.ActorId = [string]$UserId
     }

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-PublicWebhooks.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Tenant/Administration/Alerts/Invoke-PublicWebhooks.ps1
@@ -38,33 +38,43 @@ function Invoke-PublicWebhooks {
         } else {
             Write-Host 'Found matching CIPPID'
             $WebhookIncoming = Get-CIPPTable -TableName WebhookIncoming
+            $GetWebhookRowKey = {
+                param($WebhookType, $CippId, $WebhookData)
+                $WebhookJson = $WebhookData | ConvertTo-Json -Depth 20 -Compress
+                $HashInput = [System.Text.Encoding]::UTF8.GetBytes("$WebhookType|$CippId|$WebhookJson")
+                $Hash = [System.Security.Cryptography.SHA256]::Create().ComputeHash($HashInput)
+                $HashString = [System.BitConverter]::ToString($Hash).Replace('-', '').ToLowerInvariant()
+                return "$WebhookType-$HashString"
+            }
 
             if ($Request.Query.Type -eq 'GraphSubscription') {
                 # Graph Subscriptions
                 [pscustomobject]$ReceivedItem = $Request.Body.value
+                $WebhookData = [string]($ReceivedItem | ConvertTo-Json -Depth 10)
                 $Entity = [PSCustomObject]@{
                     PartitionKey = 'Webhook'
-                    RowKey       = [string](New-Guid).Guid
+                    RowKey       = [string](& $GetWebhookRowKey -WebhookType $Request.Query.Type -CippId $Request.Query.CIPPID -WebhookData $ReceivedItem)
                     Type         = $Request.Query.Type
-                    Data         = [string]($ReceivedItem | ConvertTo-Json -Depth 10)
+                    Data         = $WebhookData
                     CIPPID       = $Request.Query.CIPPID
                     WebhookInfo  = [string]($WebhookInfo | ConvertTo-Json -Depth 10)
                     FunctionName = 'PublicWebhookProcess'
                 }
-                Add-CIPPAzDataTableEntity @WebhookIncoming -Entity $Entity
+                Add-CIPPAzDataTableEntity @WebhookIncoming -Entity $Entity -Force
 
             } elseif ($Request.Query.Type -eq 'PartnerCenter') {
                 [pscustomobject]$ReceivedItem = $Request.Body
+                $WebhookData = [string]($ReceivedItem | ConvertTo-Json -Depth 10)
                 $Entity = [PSCustomObject]@{
                     PartitionKey = 'Webhook'
-                    RowKey       = [string](New-Guid).Guid
+                    RowKey       = [string](& $GetWebhookRowKey -WebhookType $Request.Query.Type -CippId $Request.Query.CIPPID -WebhookData $ReceivedItem)
                     Type         = $Request.Query.Type
-                    Data         = [string]($ReceivedItem | ConvertTo-Json -Depth 10)
+                    Data         = $WebhookData
                     CIPPID       = $Request.Query.CIPPID
                     WebhookInfo  = [string]($WebhookInfo | ConvertTo-Json -Depth 10)
                     FunctionName = 'PublicWebhookProcess'
                 }
-                Add-CIPPAzDataTableEntity @WebhookIncoming -Entity $Entity
+                Add-CIPPAzDataTableEntity @WebhookIncoming -Entity $Entity -Force
             } else {
                 $Body = 'This webhook is not authorized.'
                 $StatusCode = [HttpStatusCode]::Forbidden


### PR DESCRIPTION
## Summary
- Pins the monthly BPA scheduler to the processor path using PreferredProcessor and an explicit processor-node guard.
- Adds InvocationId to CIPP log rows so technician/user actions can be correlated with Function/App Insights telemetry.
- Deduplicates exact repeated public webhook payloads by using a deterministic WebhookIncoming RowKey instead of a random GUID.

## Why
These changes address the next performance and observability improvements for the Kalleo-hosted CIPP instance:
- avoid BPA work being picked up by user-task workers
- reduce duplicate/retry webhook flood work items
- improve technician action traceability without exposing secrets or payloads

## Cost impact
No new Azure services, no plan changes, no telemetry retention changes, no paid dependencies.

## Validation
- PowerShell parser validation passed for touched files.
- Config/CIPPTimers.json validation passed.
- git diff --check passed earlier in the branch workflow.

## Rollback
Revert this PR. The webhook dedupe uses deterministic RowKeys only for new incoming webhook rows; existing rows are not modified.